### PR TITLE
Document the purpose of calling GetToken method on collection service

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ func main() {
 	ctx := context.Background()
 
 	client := gomomo.NewClient(collectionPK, "sandbox", "https://sandbox.momodeveloper.mtn.com/")
+
+	// Calling GetToken fetches an access token and sets it onto the client
+	// All subsequent calls using the same client will be automatically set with the Authorization header using this token
 	_, err := client.Collection.GetToken(ctx, apiKey, userID)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Description

This adds a small explanation why it's necessary to make the GetToken method call on the client before subsequent calls are made.

## Type of change
Documentation

Please delete options that are not relevant.
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation